### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,13 +43,13 @@ dependencies {
     include "com.enonic.xp:lib-io:${xpVersion}"
     include "com.enonic.xp:lib-node:${xpVersion}"
     include "com.enonic.xp:lib-portal:${xpVersion}"
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.auth0:java-jwt:4.5.2"
+    include libs.lib.mustache
+    include libs.lib.static
+    include libs.java.jwt
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
-    testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.mockito.bom))
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.mockito:mockito-junit-jupiter'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+java-jwt = "4.5.2"
+junit-bom = "6.0.3"
+mockito-bom = "5.23.0"
+mustache = "2.1.1"
+static = "3.0.0-SNAPSHOT"
+
+[libraries]
+java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito-bom" }


### PR DESCRIPTION
## Summary

Moves the inline dependency version strings in `build.gradle` to a new `gradle/libs.versions.toml`. Same versions, same resolved classpath — this is a pin-for-pin refactor that gives the repo the catalog shape ~half of the IdeaProjects tree already uses, so bulk dep bumps can be done with one sed.

## Conventions adopted

- `[versions]` and `[libraries]` sorted alphabetically.
- Hyphen-separated lowercase keys (`java-jwt`, `lib-mustache`), matching the dominant style in neighbouring catalogs (`app-features`, `app-adfs-idprovider`).
- `version.ref` used so each version line stands alone.
- `xpVersion` left in `gradle.properties` and `xplibs.*` accessors left untouched — per the migration brief.
- `org.junit.jupiter:junit-jupiter`, `org.junit.platform:junit-platform-launcher`, and `org.mockito:mockito-junit-jupiter` had no inline version (they resolve via the BOMs) and stay as inline strings — minimal diff.

## New catalog

```toml
[versions]
java-jwt = "4.5.2"
junit-bom = "6.0.3"
mockito-bom = "5.23.0"
mustache = "2.1.1"
static = "3.0.0-SNAPSHOT"

[libraries]
java-jwt = { module = "com.auth0:java-jwt", version.ref = "java-jwt" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito-bom" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` and `--configuration testRuntimeClasspath` produce identical output before and after the refactor.

## Test plan

- [ ] CI build is green