### PR TITLE
stricter first login #1318

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1827,6 +1827,7 @@
       "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -2066,18 +2067,6 @@
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -2462,6 +2451,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2671,6 +2661,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3592,6 +3583,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3651,6 +3643,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3710,6 +3703,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4704,6 +4698,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4791,6 +4786,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -5270,6 +5266,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5328,6 +5325,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -6046,6 +6044,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6277,6 +6276,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6974,6 +6974,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7052,6 +7053,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.1.tgz",
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -8355,6 +8357,7 @@
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
       "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@swc/core-darwin-arm64": "1.15.40",
         "@swc/core-darwin-x64": "1.15.40",
@@ -8469,18 +8472,6 @@
       "dev": true,
       "requires": {
         "@swc/counter": "^0.1.3"
-      }
-    },
-    "@types/eslint": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
-      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
       }
     },
     "@types/estree": {
@@ -8783,7 +8774,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-import-phases": {
       "version": "1.0.3",
@@ -8913,6 +8905,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9539,6 +9532,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.27.0",
         "@esbuild/android-arm": "0.27.0",
@@ -9585,6 +9579,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9749,6 +9744,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-config-xo": {
@@ -10293,7 +10289,8 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "joycon": {
       "version": "3.1.1",
@@ -10365,6 +10362,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "copy-anything": "^3.0.5",
         "errno": "^0.1.1",
@@ -10707,7 +10705,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "pify": {
       "version": "4.0.1",
@@ -10738,6 +10737,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11176,7 +11176,8 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.1",
@@ -11341,6 +11342,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
           "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -11783,7 +11785,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.6.1",
@@ -11831,6 +11834,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.1.tgz",
       "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",

--- a/src/main/java/com/enonic/app/standardidprovider/handler/ConfigurationHandler.java
+++ b/src/main/java/com/enonic/app/standardidprovider/handler/ConfigurationHandler.java
@@ -16,8 +16,13 @@ public class ConfigurationHandler
         this.configServiceSupplier = beanContext.getService( StandardProviderConfigService.class );
     }
 
-    public boolean isLoginWithoutUserEnabled()
+    public boolean isDevMode()
     {
-        return configServiceSupplier.get().isLoginWithoutUserEnabled();
+        return configServiceSupplier.get().isDevMode();
+    }
+
+    public boolean isSuPasswordConfigured()
+    {
+        return configServiceSupplier.get().isSuPasswordConfigured();
     }
 }

--- a/src/main/java/com/enonic/app/standardidprovider/handler/StandardProviderConfigService.java
+++ b/src/main/java/com/enonic/app/standardidprovider/handler/StandardProviderConfigService.java
@@ -2,7 +2,9 @@ package com.enonic.app.standardidprovider.handler;
 
 public interface StandardProviderConfigService
 {
-    boolean isLoginWithoutUserEnabled();
+    boolean isDevMode();
+
+    boolean isSuPasswordConfigured();
 
     boolean isAutologinJwtEnabled( String idProviderKey );
 

--- a/src/main/java/com/enonic/app/standardidprovider/handler/StandardProviderConfigServiceImpl.java
+++ b/src/main/java/com/enonic/app/standardidprovider/handler/StandardProviderConfigServiceImpl.java
@@ -1,26 +1,25 @@
 package com.enonic.app.standardidprovider.handler;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 
+import com.enonic.xp.server.RunMode;
+
 @Component(immediate = true, configurationPid = "com.enonic.xp.app.standardidprovider")
 public class StandardProviderConfigServiceImpl
     implements StandardProviderConfigService
 {
-    private static final String LOGIN_WITHOUT_USER_CONFIG = "loginWithoutUser";
+    private static final String SU_PASSWORD_PROPERTY_KEY = "xp.suPassword";
 
     private static final String AUTOLOGIN_JWT_ENABLED_CONFIG = "idprovider.{{idProvider}}.autologin.jwt.enabled";
 
     private static final String AUTOLOGIN_JWT_ACCEPT_LEEWAY_CONFIG = "idprovider.{{idProvider}}.autologin.jwt.acceptLeewaySeconds";
 
     private static final String AUTOLOGIN_JWT_MAX_LIFETIME_CONFIG = "idprovider.{{idProvider}}.autologin.jwt.maxLifetimeSeconds";
-
-    private static final String DEFAULT_LOGIN_WITHOUT_USER = "true";
 
     private static final boolean DEFAULT_JWT_ENABLED = true;
 
@@ -38,10 +37,15 @@ public class StandardProviderConfigServiceImpl
     }
 
     @Override
-    public boolean isLoginWithoutUserEnabled()
+    public boolean isDevMode()
     {
-        return Boolean.parseBoolean(
-            Objects.requireNonNullElse( configuration.get( LOGIN_WITHOUT_USER_CONFIG ), DEFAULT_LOGIN_WITHOUT_USER ) );
+        return RunMode.isDev();
+    }
+
+    @Override
+    public boolean isSuPasswordConfigured()
+    {
+        return !System.getProperty( SU_PASSWORD_PROPERTY_KEY, "" ).isEmpty();
     }
 
     @Override

--- a/src/main/resources/idprovider/idprovider.html
+++ b/src/main/resources/idprovider/idprovider.html
@@ -62,12 +62,10 @@
                             </g>
                         </svg>
                     </div>
-                {{#adminUserCreation}}
+                {{#firstLogin}}
                 <div id="welcome-view" class="login-welcome-view">
                     <button type="button" id="login-as-guest-button" class="login-as-guest login-primary-button">Log In As Guest</button>
-                    {{#loginWithoutUser}}
                     <button type="button" id="create-admin-link" class="create-admin-link login-secondary-link">... or create Admin user</button>
-                    {{/loginWithoutUser}}
                     <div id="welcome-message-container" class="login-message-container" role="alert" aria-live="polite"></div>
                 </div>
                 <form id="creation-view" class="login-creation-view" hidden novalidate>
@@ -100,13 +98,11 @@
                         <div id="invalid-confirm-password-message" class="login-field-error" role="alert">Passwords don't match!</div>
                     </div>
                     <button type="submit" id="create-admin-button" class="create-admin-button login-primary-button" disabled>Create Admin User</button>
-                    {{#loginWithoutUser}}
                     <button type="button" id="login-as-guest-link" class="login-as-guest login-secondary-link">... or log in as Guest</button>
-                    {{/loginWithoutUser}}
                     <div id="message-container" class="login-message-container" role="alert" aria-live="polite"></div>
                 </form>
-                {{/adminUserCreation}}
-                {{^adminUserCreation}}
+                {{/firstLogin}}
+                {{^firstLogin}}
                 <form id="login-form" class="login-form" novalidate>
                     <div class="login-fieldset">
                         <label id="username-label" class="login-label" for="username-input">Username</label>
@@ -119,7 +115,7 @@
                     <button type="submit" id="login-button" class="login-button login-primary-button" disabled>Log In</button>
                     <div id="message-container" class="login-message-container" role="alert" aria-live="polite"></div>
                 </form>
-                {{/adminUserCreation}}
+                {{/firstLogin}}
                 </div>
             </div>
         </div>

--- a/src/main/resources/idprovider/idprovider.ts
+++ b/src/main/resources/idprovider/idprovider.ts
@@ -1,31 +1,17 @@
 // External libs
 // @ts-expect-error No types
-import { render } from '/lib/mustache';
+import {render} from '/lib/mustache';
 
-import {
-    getIdProviderKey,
-    getSite,
-    idProviderUrl,
-    pageUrl
-} from '/lib/xp/portal';
-import { login as authLogin, logout as authLogout } from '/lib/xp/auth';
-import {
-    requestHandler,
-    RESPONSE_CACHE_CONTROL,
-    mappedRelativePath
-} from '/lib/enonic/static';
-import { readJsonResourceProperty } from '/lib/standardidprovider/resource';
-import { Request, Response } from '@enonic-types/core';
+import {getIdProviderKey, getSite, idProviderUrl, pageUrl} from '/lib/xp/portal';
+import {login as authLogin, logout as authLogout} from '/lib/xp/auth';
+import {mappedRelativePath, requestHandler, RESPONSE_CACHE_CONTROL} from '/lib/enonic/static';
+import {readJsonResourceProperty} from '/lib/standardidprovider/resource';
+import {Request, Response} from '@enonic-types/core';
 
 // Local libs
-import {
-    adminUserCreationEnabled,
-    canLoginAsSu,
-    createAdminUserCreation,
-    loginWithoutUserEnabled
-} from '/lib/admin-creation';
-import { autoLogin as libAutoLogin } from '/lib/autologin';
-import { getConfig } from '/lib/config';
+import {createAdminUserCreation, firstLoginEnabled} from '/lib/admin-creation';
+import {autoLogin as libAutoLogin} from '/lib/autologin';
+import {getConfig} from '/lib/config';
 
 const STATIC_ASSETS_SLASH_API_REGEXP =
     /^\/api\/idprovider\/[^/]+\/_static\/.+$/;
@@ -101,7 +87,7 @@ export const post = (req: Request) => {
             break;
         case 'loginAsSu':
             result =
-                canLoginAsSu() &&
+                firstLoginEnabled() &&
                 authLogin({
                     user: 'su',
                     idProvider: 'system',
@@ -165,8 +151,7 @@ function generateRedirectUrl() {
 }
 
 function generateLoginPage(req: Request, redirectUrl?: string) {
-    const adminUserCreation = adminUserCreationEnabled();
-    const loginWithoutUser = loginWithoutUserEnabled();
+    const firstLogin = firstLoginEnabled();
     const baseUrlPrefix = `${idProviderUrl({})}/${BASE}/${readJsonResourceProperty('/static/buildtime.json', 'timeSinceEpoch')}`;
 
     const view = resolve('idprovider.html');
@@ -181,8 +166,7 @@ function generateLoginPage(req: Request, redirectUrl?: string) {
         imageUrlPrefix: `${baseUrlPrefix}/icons`,
         installation: config.installation,
         xpVersion: config.xpVersion,
-        adminUserCreation,
-        loginWithoutUser,
+        firstLogin,
         configScriptId: Math.random().toString(36).substring(2, 15),
         configJson: JSON.stringify(config, null, 4).replace(
             /<(\/?script|!--)/gi,

--- a/src/main/resources/lib/admin-creation.ts
+++ b/src/main/resources/lib/admin-creation.ts
@@ -2,24 +2,24 @@ import {
     addMembers,
     changePassword,
     createUser,
-    getIdProviderConfig,
+    getMembers,
     login
 } from '/lib/xp/auth';
-import { connect as nodeConnect } from '/lib/xp/node';
 import { getIdProviderKey } from '/lib/xp/portal';
 import { run } from '/lib/xp/context';
-import { isLoginWithoutUserEnabled } from './config';
+import { isDevMode, isSuPasswordConfigured } from './config';
 
-export function adminUserCreationEnabled() {
-    return isSystemIdProvider() && checkFlag();
+const SU_KEY = 'user:system:su';
+const ADMIN_ROLE = 'role:system.admin';
+
+export function firstLoginEnabled() {
+    return (
+        isSystemIdProvider() &&
+        isDevMode() &&
+        !isSuPasswordConfigured() &&
+        !adminUserExists()
+    );
 }
-
-export function loginWithoutUserEnabled() {
-    return isLoginWithoutUserEnabled();
-}
-
-export const canLoginAsSu = () =>
-    adminUserCreationEnabled() && loginWithoutUserEnabled();
 
 export const createAdminUserCreation = (params: {
     idProvider: string;
@@ -27,7 +27,7 @@ export const createAdminUserCreation = (params: {
     email: string;
     password: string;
 }) => {
-    if (adminUserCreationEnabled()) {
+    if (firstLoginEnabled()) {
         return runAsAdmin(() => {
             const createdUser = createUser({
                 idProvider: 'system',
@@ -45,17 +45,11 @@ export const createAdminUserCreation = (params: {
                 addMembers('role:system.admin', [createdUser.key]);
                 addMembers('role:system.admin.login', [createdUser.key]);
 
-                const loginResult = login({
+                return login({
                     user: params.user,
                     password: params.password,
                     idProvider: 'system'
                 });
-
-                if (loginResult && loginResult.authenticated) {
-                    setFlag();
-                }
-
-                return loginResult;
             }
 
             return undefined;
@@ -69,34 +63,20 @@ function isSystemIdProvider() {
     return getIdProviderKey() === 'system';
 }
 
-function checkFlag() {
-    const idProviderConfig = getIdProviderConfig();
-    return (
-        idProviderConfig && idProviderConfig.adminUserCreationEnabled === true
-    );
-}
-
-function setFlag() {
-    connect().update<{
-        idProvider?: {
-            config?: {
-                adminUserCreationEnabled?: boolean;
-            };
-        };
-    }>({
-        key: '/identity/system',
-        editor(systemIdProvider) {
-            if (
-                systemIdProvider.idProvider &&
-                systemIdProvider.idProvider.config
-            ) {
-                const cfg = systemIdProvider.idProvider.config;
-                delete cfg.adminUserCreationEnabled;
+// True if any user other than su has the admin role, directly or via a group.
+// XP has no nested groups, so a single descent into group members is enough.
+function adminUserExists(): boolean {
+    return runAsAdmin(() =>
+        getMembers(ADMIN_ROLE).some((member) => {
+            if (member.type === 'group') {
+                return getMembers(member.key).some(
+                    (groupMember) => groupMember.key !== SU_KEY
+                );
             }
 
-            return systemIdProvider;
-        }
-    });
+            return member.key !== SU_KEY;
+        })
+    );
 }
 
 function runAsAdmin<T>(callback: () => T) {
@@ -108,12 +88,4 @@ function runAsAdmin<T>(callback: () => T) {
         },
         callback
     );
-}
-
-function connect() {
-    return nodeConnect({
-        repoId: 'system-repo',
-        branch: 'master',
-        principals: ['role:system.admin']
-    });
 }

--- a/src/main/resources/lib/config.ts
+++ b/src/main/resources/lib/config.ts
@@ -19,11 +19,14 @@ interface Config {
 
 // eslint-disable-next-line no-undef
 const configBean = __.newBean<{
-    isLoginWithoutUserEnabled: () => boolean;
+    isDevMode: () => boolean;
+    isSuPasswordConfigured: () => boolean;
 }>('com.enonic.app.standardidprovider.handler.ConfigurationHandler');
 
-export const isLoginWithoutUserEnabled = () =>
-    configBean.isLoginWithoutUserEnabled();
+export const isDevMode = () => configBean.isDevMode();
+
+export const isSuPasswordConfigured = () =>
+    configBean.isSuPasswordConfigured();
 
 export const getConfig = (req: RequestExt): Config => ({
     idProviderKey: getIdProviderKey(),

--- a/src/test/java/com/enonic/app/standardidprovider/handler/AdminCreationTest.java
+++ b/src/test/java/com/enonic/app/standardidprovider/handler/AdminCreationTest.java
@@ -1,0 +1,136 @@
+package com.enonic.app.standardidprovider.handler;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderKey;
+import com.enonic.xp.security.Group;
+import com.enonic.xp.security.Principal;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.PrincipalKeys;
+import com.enonic.xp.security.PrincipalRelationship;
+import com.enonic.xp.security.PrincipalRelationships;
+import com.enonic.xp.security.Principals;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.User;
+import com.enonic.xp.testing.ScriptTestSupport;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdminCreationTest
+    extends ScriptTestSupport
+{
+    private SecurityService securityService;
+
+    private StandardProviderConfigService configService;
+
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+
+        securityService = Mockito.mock( SecurityService.class );
+        configService = Mockito.mock( StandardProviderConfigService.class );
+
+        addService( SecurityService.class, securityService );
+        addService( StandardProviderConfigService.class, configService );
+
+        // getIdProviderKey() reads the bound PortalRequest; make it the system id provider.
+        this.portalRequest = Mockito.mock( PortalRequest.class );
+        Mockito.when( this.portalRequest.getIdProvider() ).thenReturn( IdProvider.create().key( IdProviderKey.system() ).build() );
+
+        // getPrincipals returns a bare principal for each requested key (key prefix decides type).
+        Mockito.when( securityService.getPrincipals( Mockito.any( PrincipalKeys.class ) ) ).thenAnswer( invocation -> {
+            final PrincipalKeys keys = invocation.getArgument( 0 );
+            return Principals.from( keys.stream().map( AdminCreationTest::principalOf ).toArray( Principal[]::new ) );
+        } );
+
+        // Default: only su is a member of the admin role.
+        adminRoleMembers( PrincipalKey.ofSuperUser() );
+    }
+
+    private static Principal principalOf( final PrincipalKey key )
+    {
+        if ( key.isGroup() )
+        {
+            return Group.create().key( key ).displayName( key.getId() ).build();
+        }
+        return User.create().key( key ).login( key.getId() ).build();
+    }
+
+    private void membersOf( final PrincipalKey container, final PrincipalKey... members )
+    {
+        Mockito.when( securityService.getRelationships( container ) ).thenReturn( PrincipalRelationships.from(
+            Arrays.stream( members ).map( m -> PrincipalRelationship.from( container ).to( m ) ).toArray( PrincipalRelationship[]::new ) ) );
+    }
+
+    private void adminRoleMembers( final PrincipalKey... members )
+    {
+        membersOf( RoleKeys.ADMIN, members );
+    }
+
+    private boolean firstLoginEnabled()
+    {
+        final ScriptValue result = runFunction( "/test/admin-creation-test.js", "firstLoginEnabled" );
+        return result.getValue( Boolean.class );
+    }
+
+    @Test
+    public void enabled_when_dev_no_su_password_and_only_su_is_admin()
+    {
+        Mockito.when( configService.isDevMode() ).thenReturn( true );
+        Mockito.when( configService.isSuPasswordConfigured() ).thenReturn( false );
+
+        assertTrue( firstLoginEnabled() );
+    }
+
+    @Test
+    public void disabled_when_not_dev_mode()
+    {
+        Mockito.when( configService.isDevMode() ).thenReturn( false );
+        Mockito.when( configService.isSuPasswordConfigured() ).thenReturn( false );
+
+        assertFalse( firstLoginEnabled() );
+    }
+
+    @Test
+    public void disabled_when_su_password_configured()
+    {
+        Mockito.when( configService.isDevMode() ).thenReturn( true );
+        Mockito.when( configService.isSuPasswordConfigured() ).thenReturn( true );
+
+        assertFalse( firstLoginEnabled() );
+    }
+
+    @Test
+    public void disabled_when_a_non_su_user_is_admin()
+    {
+        Mockito.when( configService.isDevMode() ).thenReturn( true );
+        Mockito.when( configService.isSuPasswordConfigured() ).thenReturn( false );
+
+        adminRoleMembers( PrincipalKey.ofSuperUser(), PrincipalKey.from( "user:system:alice" ) );
+
+        assertFalse( firstLoginEnabled() );
+    }
+
+    @Test
+    public void disabled_when_admin_granted_via_group()
+    {
+        Mockito.when( configService.isDevMode() ).thenReturn( true );
+        Mockito.when( configService.isSuPasswordConfigured() ).thenReturn( false );
+
+        final PrincipalKey admins = PrincipalKey.from( "group:system:admins" );
+        adminRoleMembers( PrincipalKey.ofSuperUser(), admins );
+        membersOf( admins, PrincipalKey.from( "user:system:bob" ) );
+
+        assertFalse( firstLoginEnabled() );
+    }
+}

--- a/src/test/java/com/enonic/app/standardidprovider/handler/ConfigurationHandlerTest.java
+++ b/src/test/java/com/enonic/app/standardidprovider/handler/ConfigurationHandlerTest.java
@@ -12,11 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ConfigurationHandlerTest
 {
     @Test
-    public void test()
+    public void autologin_jwt_config()
     {
         Map<String, String> configurations = new HashMap<>();
 
-        configurations.put( "loginWithoutUser", "false" );
         configurations.put( "idprovider.system.autologin.jwt.enabled", "true" );
         configurations.put( "idprovider.system.autologin.jwt.acceptLeewaySeconds", "10" );
         configurations.put( "idprovider.system.autologin.jwt.maxLifetimeSeconds", "35" );
@@ -24,7 +23,6 @@ public class ConfigurationHandlerTest
         StandardProviderConfigServiceImpl service = new StandardProviderConfigServiceImpl();
         service.activate( configurations );
 
-        assertFalse( service.isLoginWithoutUserEnabled() );
         assertTrue( service.isAutologinJwtEnabled( "system" ) );
         assertTrue( service.isAutologinJwtEnabled( "unknown" ) );
         assertEquals( 35L, service.getAutologinJwtLifetimeSeconds( "system" ) );
@@ -32,14 +30,53 @@ public class ConfigurationHandlerTest
         assertEquals( 30L, service.getAutologinJwtLifetimeSeconds( "unknown" ) );
         assertEquals( -1L, service.getAutologinJwtAcceptLeewaySeconds( "unknown" ) );
 
-        configurations.put( "loginWithoutUser", "true" );
         configurations.put( "idprovider.system.autologin.jwt.enabled", "false" );
 
         service = new StandardProviderConfigServiceImpl();
         service.activate( configurations );
 
-        assertTrue( service.isLoginWithoutUserEnabled() );
         assertFalse( service.isAutologinJwtEnabled( "system" ) );
         assertTrue( service.isAutologinJwtEnabled( "unknown" ) );
+    }
+
+    @Test
+    public void isDevMode_is_false_in_prod_test_runtime()
+    {
+        StandardProviderConfigServiceImpl service = new StandardProviderConfigServiceImpl();
+        service.activate( new HashMap<>() );
+
+        // Tests run with the default PROD run mode.
+        assertFalse( service.isDevMode() );
+    }
+
+    @Test
+    public void isSuPasswordConfigured_reflects_system_property()
+    {
+        StandardProviderConfigServiceImpl service = new StandardProviderConfigServiceImpl();
+        service.activate( new HashMap<>() );
+
+        final String previous = System.getProperty( "xp.suPassword" );
+        try
+        {
+            System.clearProperty( "xp.suPassword" );
+            assertFalse( service.isSuPasswordConfigured() );
+
+            System.setProperty( "xp.suPassword", "{sha512}abc" );
+            assertTrue( service.isSuPasswordConfigured() );
+
+            System.setProperty( "xp.suPassword", "" );
+            assertFalse( service.isSuPasswordConfigured() );
+        }
+        finally
+        {
+            if ( previous == null )
+            {
+                System.clearProperty( "xp.suPassword" );
+            }
+            else
+            {
+                System.setProperty( "xp.suPassword", previous );
+            }
+        }
     }
 }

--- a/src/test/resources/test/admin-creation-test.js
+++ b/src/test/resources/test/admin-creation-test.js
@@ -1,0 +1,5 @@
+const adminCreationLib = require('/lib/admin-creation');
+
+exports.firstLoginEnabled = function () {
+    return adminCreationLib.firstLoginEnabled();
+};


### PR DESCRIPTION
First login (passwordless guest/su and admin-user creation) is now enabled only when all hold: dev run mode, xp.suPassword not set, and no admin-role user other than su exists. The adminUserCreationEnabled IdP flag is no longer read or written, and the loginWithoutUser config is removed.

Detection of dev mode and su-password lives on StandardProviderConfigService so it can be mocked; firstLoginEnabled/adminUserExists are covered by a new ScriptTestSupport JS harness (AdminCreationTest).